### PR TITLE
Remove handle from list of things to retweet

### DIFF
--- a/LuckyPenny.py
+++ b/LuckyPenny.py
@@ -46,7 +46,7 @@ def retweet():
     sh.perform_parallel_action(
             'retweet',
             sleep = 60,
-            capacity = 20,
+            capacity = 200,
             search_terms = ['#commonspilot','@nih_dcppc'],
             follow = True
     )
@@ -59,8 +59,8 @@ def favorite():
     sh.perform_parallel_action(
             'favorite',
             sleep = 60,
-            capacity = 20,
-            search_terms = ['#commonspilot','@nih_dcppc'],
+            capacity = 200,
+            search_terms = ['#commonspilot'],
             follow = True
     )
 


### PR DESCRIPTION
The problem with retweeting everything using the bot handle
is that we end up retweeting entire threads, most of which are
totally irrelevant.

This commit removes the bot handle from the list of terms that
are retweeted, so that we do not end up retweeting these
(in all likelihood irrelevant) tweets.